### PR TITLE
Rebuild Docker + patch ChatOllama missing base_url param

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,9 +1,18 @@
 FROM python:3.12.4
 
+### Messy workaround to get the latest version of ChatOllama with support for base_url
+RUN apt-get -y update
+RUN apt-get -y install git
+
+RUN git clone https://github.com/langchain-ai/langchain.git
+RUN cd langchain/libs/partners/ollama && pip install -e .
+RUN cd
+### End of workaround
+
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/app/ai.py
+++ b/app/ai.py
@@ -15,10 +15,9 @@ class OpenAIModels(Enum):
 
 class OllamaModels(Enum):
     LLAMA3_1 = "llama3.1:8b"
-    if os.getenv("ENV", "development") == "production":
-        CODE_LLAMA = "codellama:7b"
-        GEMMA2 = "gemma2:9b"
-        MISTRAL_NEMO = "mistral-nemo"
+    CODE_LLAMA = "codellama:7b"
+    GEMMA2 = "gemma2:9b"
+    MISTRAL_NEMO = "mistral-nemo"
 
 AVAILABLE_MODELS = [*[m.value for m in OllamaModels],*[m.value for m in OpenAIModels]]
 MAX_TOKEN_VALUES = [512, 1024, 2048, 4096, 8192]
@@ -38,4 +37,5 @@ def get_client(model:str, temp:float, max_tokens:int):
             model=model,
             temperature=temp,
             num_predict=max_tokens,
+            base_url="http://ollama:11434"
         )

--- a/app/compose.dev.yml
+++ b/app/compose.dev.yml
@@ -1,0 +1,14 @@
+  ollama:
+    image: ollama/ollama:latest
+    hostname: ollama
+    ports:
+      - 11434:11434
+    volumes:
+      - ${MODELS_PATH}:/root/.ollama
+    container_name: ollama
+    pull_policy: always
+    tty: true
+    restart: always
+    environment:
+      - OLLAMA_KEEP_ALIVE=24h
+      - OLLAMA_HOST=0.0.0.0

--- a/app/compose.prod.yml
+++ b/app/compose.prod.yml
@@ -1,0 +1,21 @@
+  ollama:
+    image: ollama/ollama:latest
+    hostname: ollama
+    ports:
+      - 11434:11434
+    volumes:
+      - ${MODELS_PATH}:/root/.ollama
+    container_name: ollama
+    pull_policy: always
+    tty: true
+    restart: always
+    environment:
+      - OLLAMA_KEEP_ALIVE=24h
+      - OLLAMA_HOST=0.0.0.0
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/app/compose.yaml
+++ b/app/compose.yaml
@@ -1,8 +1,33 @@
-version: '3.8'
-
 services:
   streamlit:
     build: .
-    network_mode: "host"
     environment:
-      - ENV=${ENV}
+      - AUTH_USERS=${AUTH_USERS}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - REDIRECT_URI=${REDIRECT_URI}
+    ports:
+      - '8501:8501'
+    depends_on:
+      - ollama
+    
+  ollama:
+    image: ollama/ollama:latest
+    hostname: ollama
+    ports:
+      - 11434:11434
+    volumes:
+      - ${MODELS_PATH}:/root/.ollama
+    container_name: ollama
+    pull_policy: always
+    tty: true
+    restart: always
+    environment:
+      - OLLAMA_KEEP_ALIVE=24h
+      - OLLAMA_HOST=0.0.0.0
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]

--- a/app/requirements.in
+++ b/app/requirements.in
@@ -1,8 +1,8 @@
 pydantic>=2.8
-langchain>=0.2
-langchain-openai>=0.1
-langchain-ollama
-streamlit>=1.37.0
+langchain==0.2.11
+langchain-openai==0.1.19
+#langchain-ollama==0.1.0
+streamlit==1.37
 google-auth-oauthlib
 google-api-python-client
 python-dotenv==1.0.1

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -71,9 +71,7 @@ httplib2==0.22.0
     #   google-api-python-client
     #   google-auth-httplib2
 httpx==0.27.0
-    # via
-    #   ollama
-    #   openai
+    # via openai
 idna==3.7
     # via
     #   anyio
@@ -94,15 +92,12 @@ jsonschema-specifications==2023.12.1
     # via jsonschema
 langchain==0.2.11
     # via -r requirements.in
-langchain-core==0.2.23
+langchain-core==0.2.24
     # via
     #   langchain
-    #   langchain-ollama
     #   langchain-openai
     #   langchain-text-splitters
-langchain-ollama==0.1.0
-    # via -r requirements.in
-langchain-openai==0.1.14
+langchain-openai==0.1.19
     # via -r requirements.in
 langchain-text-splitters==0.2.2
     # via langchain
@@ -130,8 +125,6 @@ numpy==1.26.4
     #   streamlit
 oauthlib==3.2.2
     # via requests-oauthlib
-ollama==0.3.0
-    # via langchain-ollama
 openai==1.37.1
     # via langchain-openai
 orjson==3.10.6
@@ -163,14 +156,14 @@ pyasn1==0.6.0
     #   rsa
 pyasn1-modules==0.4.0
     # via google-auth
-pydantic==2.8.2
+pydantic==2.8.0
     # via
     #   -r requirements.in
     #   langchain
     #   langchain-core
     #   langsmith
     #   openai
-pydantic-core==2.20.1
+pydantic-core==2.20.0
     # via pydantic
 pydeck==0.9.1
     # via streamlit


### PR DESCRIPTION
ChatOllama has been [updated](https://github.com/langchain-ai/langchain/commit/df37c0d086dcdfa1ed0af6c9fb31cdb32c441574) to support base_url, which should allow us to run Ollama in a docker container.

The pypi package has not been updated so we build the package by cloning the repo.